### PR TITLE
Avoid using the map/lambda to unpack tuple series into two new columns

### DIFF
--- a/eclipse.py
+++ b/eclipse.py
@@ -45,8 +45,7 @@ def parse_kml(kml):
     return lons, lats
 
 coords = states.geometry.map(parse_kml)
-states["lons"] = coords.map(lambda row: row[0])
-states["lats"] = coords.map(lambda row: row[1])
+states[['lons', 'lats']] = coords.apply(pd.Series)
 
 from bokeh.plotting import figure, show
 


### PR DESCRIPTION
I think this is what you where asking for during the workshop.

The other syntax you can use is:

`states['lons'], states['lats'] = coords.str[0], coords.str[1]`